### PR TITLE
Fix OpenCV error

### DIFF
--- a/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
+++ b/ar_track_alvar/nodes/IndividualMarkersNoKinect.cpp
@@ -224,7 +224,7 @@ void getCapCallback(const sensor_msgs::ImageConstPtr& image_msg)
     }
     catch (const std::exception& e)
     {
-      ROS_ERROR("Error in ar_track_alvar callback");
+      ROS_ERROR("Error in ar_track_alvar callback: %s", e.what());
     }
   }
 }

--- a/ar_track_alvar/src/Camera.cpp
+++ b/ar_track_alvar/src/Camera.cpp
@@ -873,16 +873,18 @@ void Homography::ProjectPoints(const vector<PointDouble>& from,
   src_pts = cv::Mat(1, size, CV_64FC3, srcp);
   dst_pts = cv::Mat(1, size, CV_64FC3, dstp);
 
-  cv::transform(src_pts, dst_pts, H);
+  if (! H.empty()) {
+    cv::transform(src_pts, dst_pts, H);
 
-  to.clear();
-  for (int i = 0; i < size; ++i)
-  {
-    PointDouble pt;
-    pt.x = dstp[i].x / dstp[i].z;
-    pt.y = dstp[i].y / dstp[i].z;
+    to.clear();
+    for (int i = 0; i < size; ++i)
+    {
+      PointDouble pt;
+      pt.x = dstp[i].x / dstp[i].z;
+      pt.y = dstp[i].y / dstp[i].z;
 
-    to.push_back(pt);
+      to.push_back(pt);
+    }
   }
 }
 


### PR DESCRIPTION
The following error occured sometimes:

```
Error in ar_track_alvar callback: OpenCV(4.2.0) ../modules/core/src/matmul.dispatch.cpp:439: error: (-215:Assertion failed) scn == m.cols || scn + 1 == m.cols in function 'transform'
```

This shouldn't be the case anymore.